### PR TITLE
Oppretter api for dialogmelding + swagger

### DIFF
--- a/api/oas3/isyfomock-api.yaml
+++ b/api/oas3/isyfomock-api.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.0
+
+info:
+  title: isyfomock API
+  description: API for Team iSYFO sin mock
+  version: 1.0.0
+servers:
+  - url: 'https://isyfomock.dev.intern.nav.no'
+paths:
+  /dialogmelding/opprett:
+    post:
+      operationId: opprettDialogmelding
+      tags:
+        - Dialogmelding
+      summary: Oppretter dialogmelding til padm2
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OpprettDialogmeldingRequest'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal server error
+
+components:
+  schemas:
+    OpprettDialogmeldingRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type dialogmelding
+          enum:
+            - VANLIG
+            - VEDLEGG,
+            - SVAR_MOTEINNKALLING
+            - SVAR_FORESPORSEL
+            - SVAR_FORESPORSEL_VEDLEGG
+        pasientFnr:
+          type: string
+          description: Fødselsnummer til pasient
+        legeFnr:
+          type: string
+          description: Fødselsnummer til lege
+          example: '01117302624'
+        notat:
+          description: Notat
+          type: string
+        refToParent:
+          description: Referanse til forrige melding i dialogen
+          type: string
+        refToConversation:
+          description: Referanse til start-meldingen i dialogen
+          type: string
+      required:
+        - type
+        - pasientFnr
+        - legeFnr

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,12 +10,14 @@ object Versions {
     const val logstashEncoder = "7.0.1"
     const val micrometerRegistry = "1.8.4"
     const val spek = "2.0.18"
+    const val swaggerUi = "4.9.1"
 }
 
 plugins {
     kotlin("jvm") version "1.6.10"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    id("org.hidetake.swagger.generator") version "2.19.2" apply true
 }
 
 val githubUser: String by project
@@ -44,6 +46,8 @@ dependencies {
     // (De-)serialization
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${Versions.jackson}")
 
+    swaggerUI("org.webjars:swagger-ui:${Versions.swaggerUi}")
+
     testImplementation("io.ktor:ktor-server-test-host:${Versions.ktor}")
     testImplementation("io.mockk:mockk:${Versions.mockk}")
     testImplementation("org.amshove.kluent:kluent:${Versions.kluent}")
@@ -52,6 +56,12 @@ dependencies {
     }
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:${Versions.spek}") {
         exclude(group = "org.jetbrains.kotlin")
+    }
+}
+
+swaggerSources {
+    create("isyfomock").apply {
+        setInputFile(file("api/oas3/isyfomock-api.yaml"))
     }
 }
 
@@ -70,10 +80,15 @@ tasks {
         kotlinOptions.jvmTarget = "17"
     }
 
+    withType<org.hidetake.gradle.swagger.generator.GenerateSwaggerUI> {
+        outputDir = File(buildDir.path + "/resources/main/api")
+    }
+
     withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
         archiveBaseName.set("app")
         archiveClassifier.set("")
         archiveVersion.set("")
+        dependsOn("generateSwaggerUI")
     }
 
     withType<Test> {

--- a/src/main/kotlin/no/nav/syfo/Application.kt
+++ b/src/main/kotlin/no/nav/syfo/Application.kt
@@ -5,20 +5,25 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.api.apiModule
+import no.nav.syfo.mq.MQSender
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
+val log: Logger = LoggerFactory.getLogger("no.nav.syfo.isyfomock")
+
 fun main() {
     val environment = Environment()
+    val mqSender = MQSender(environment)
     val applicationState = ApplicationState()
     val applicationEngineEnvironment = applicationEngineEnvironment {
-        log = LoggerFactory.getLogger("no.nav.syfo.isyfomock")
         connector {
             port = environment.applicationPort
         }
         module {
             apiModule(
-                applicationState = applicationState
+                mqSender = mqSender,
+                applicationState = applicationState,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.application.api
 
 import io.ktor.application.*
+import io.ktor.client.features.*
 import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.jackson.*
@@ -9,9 +10,13 @@ import io.ktor.routing.*
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.metric.registerMetricApi
 import no.nav.syfo.configureJacksonMapper
+import no.nav.syfo.dialogmelding.DialogmeldingService
+import no.nav.syfo.dialogmelding.api.registerDialogmeldingApi
+import no.nav.syfo.mq.MQSender
 
 fun Application.apiModule(
     applicationState: ApplicationState,
+    mqSender: MQSender,
 ) {
     install(ContentNegotiation) {
         jackson(block = configureJacksonMapper())
@@ -19,11 +24,32 @@ fun Application.apiModule(
     install(StatusPages) {
         exception<Throwable> { cause ->
             log.error("Caught exception", cause)
-            call.respond(HttpStatusCode.InternalServerError, cause.message ?: "Unknown error")
+
+            val response: Pair<HttpStatusCode, String> = when (cause) {
+                is ResponseException -> Pair(
+                    cause.response.status,
+                    cause.message ?: "Unknown error"
+                )
+                is IllegalArgumentException -> Pair(
+                    HttpStatusCode.BadRequest,
+                    cause.message ?: "Unknown error"
+                )
+                else -> Pair(
+                    HttpStatusCode.InternalServerError,
+                    "The server reported an unexpected error and cannot complete the request."
+                )
+            }
+
+            call.respond(response.first, response.second)
         }
     }
+
+    val dialogmeldingService = DialogmeldingService(mqSender = mqSender)
+
     routing {
         registerPodApi(applicationState = applicationState)
         registerMetricApi()
+        registerSwaggerDocApi()
+        registerDialogmeldingApi(dialogmeldingService = dialogmeldingService)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/application/api/SwaggerApi.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/SwaggerApi.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.application.api
+
+import io.ktor.http.content.*
+import io.ktor.routing.*
+
+fun Route.registerSwaggerDocApi() {
+    route("/api/v1/docs/") {
+        static {
+            resources("api")
+            defaultResource("api/index.html")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/dialogmelding/DialogmeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/DialogmeldingService.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.dialogmelding
+
+import no.nav.syfo.dialogmelding.model.OpprettDialogmeldingRequest
+import no.nav.syfo.mq.MQSender
+
+class DialogmeldingService(private val mqSender: MQSender) {
+
+    fun opprettDialogmelding(request: OpprettDialogmeldingRequest) {
+        // TODO: Implement sending dialogmelding to padm2
+        mqSender.send("")
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/dialogmelding/api/DialogmeldingApi.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/api/DialogmeldingApi.kt
@@ -1,0 +1,45 @@
+package no.nav.syfo.dialogmelding.api
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.util.*
+import no.nav.syfo.dialogmelding.DialogmeldingService
+import no.nav.syfo.dialogmelding.model.DialogmeldingType
+import no.nav.syfo.dialogmelding.model.OpprettDialogmeldingRequest
+import no.nav.syfo.log
+import no.nav.syfo.model.PersonIdent
+import java.util.*
+
+object OpprettDialogmeldingRequestParameters {
+    const val type = "type"
+    const val pasientFnr = "pasientFnr"
+    const val legeFnr = "legeFnr"
+    const val notat = "notat"
+    const val refToParent = "refToParent"
+    const val refToConversation = "refToConversation"
+}
+
+fun Route.registerDialogmeldingApi(dialogmeldingService: DialogmeldingService) {
+    post("/dialogmelding/opprett") {
+        val formParameters = call.receiveParameters()
+        val msgId = UUID.randomUUID().toString()
+        val request = OpprettDialogmeldingRequest(
+            msgId = msgId,
+            type = DialogmeldingType.valueOf(formParameters.getOrFail(OpprettDialogmeldingRequestParameters.type)),
+            pasientFnr = PersonIdent(formParameters.getOrFail(OpprettDialogmeldingRequestParameters.pasientFnr)),
+            legeFnr = PersonIdent(formParameters.getOrFail(OpprettDialogmeldingRequestParameters.legeFnr)),
+            notat = formParameters[OpprettDialogmeldingRequestParameters.notat],
+            refToParent = formParameters[OpprettDialogmeldingRequestParameters.refToParent],
+            refToConversation = formParameters[OpprettDialogmeldingRequestParameters.refToConversation],
+        )
+
+        dialogmeldingService.opprettDialogmelding(request)
+
+        log.info("Dialogmelding opprettet")
+
+        call.respond(HttpStatusCode.OK, "Opprettet dialogmelding med msgId $msgId")
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/dialogmelding/model/DialogmeldingType.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/model/DialogmeldingType.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.dialogmelding.model
+
+enum class DialogmeldingType {
+    VANLIG,
+    VEDLEGG,
+    SVAR_MOTEINNKALLING,
+    SVAR_FORESPORSEL,
+    SVAR_FORESPORSEL_VEDLEGG,
+}

--- a/src/main/kotlin/no/nav/syfo/dialogmelding/model/OpprettDialogmeldingRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmelding/model/OpprettDialogmeldingRequest.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.dialogmelding.model
+
+import no.nav.syfo.model.PersonIdent
+
+data class OpprettDialogmeldingRequest(
+    val type: DialogmeldingType,
+    val msgId: String,
+    val pasientFnr: PersonIdent,
+    val legeFnr: PersonIdent,
+    val notat: String?,
+    val refToParent: String?,
+    val refToConversation: String?,
+)

--- a/src/main/kotlin/no/nav/syfo/model/PersonIdent.kt
+++ b/src/main/kotlin/no/nav/syfo/model/PersonIdent.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.model
+
+data class PersonIdent(val value: String) {
+    private val elevenDigits = Regex("^\\d{11}\$")
+
+    init {
+        if (!elevenDigits.matches(value)) {
+            throw IllegalArgumentException("Value is not a valid PersonIdent")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/mq/MQSender.kt
+++ b/src/main/kotlin/no/nav/syfo/mq/MQSender.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.mq
+
+import no.nav.syfo.Environment
+
+class MQSender(private val env: Environment) {
+    fun send(message: String) {
+        // TODO: Implement send message to padm2
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/application.api/PodApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application.api/PodApiSpek.kt
@@ -39,7 +39,7 @@ object PodApiSpek : Spek({
                 applicationState = ApplicationState(
                     alive = false,
                     ready = false,
-                )
+                ),
             )
 
             it("Returns internal server error when liveness check fails") {

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/api/DialogmeldingApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/api/DialogmeldingApiSpek.kt
@@ -1,0 +1,52 @@
+package no.nav.syfo.dialogmelding.api
+
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import io.mockk.*
+import no.nav.syfo.dialogmelding.model.*
+import no.nav.syfo.mq.MQSender
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import testhelper.testApiModule
+
+class DialogmeldingApiSpek : Spek({
+
+    val pasientFnr = "12345678912"
+    val legeFnr = "23456789123"
+    val notat = "kjempefint notat"
+
+    with(TestApplicationEngine()) {
+        start()
+
+        val mqSender = mockk<MQSender>()
+        justRun { mqSender.send(any()) }
+
+        application.testApiModule(mqSender = mqSender)
+
+        describe(DialogmeldingApiSpek::class.java.simpleName) {
+            describe("Opprett dialogmelding") {
+                val url = "/dialogmelding/opprett"
+                it("oppretter vanlig dialogmelding") {
+                    val requestParameters = listOf(
+                        OpprettDialogmeldingRequestParameters.pasientFnr to pasientFnr,
+                        OpprettDialogmeldingRequestParameters.notat to notat,
+                        OpprettDialogmeldingRequestParameters.legeFnr to legeFnr,
+                        OpprettDialogmeldingRequestParameters.type to DialogmeldingType.VANLIG.toString(),
+                    )
+
+                    with(
+                        handleRequest(HttpMethod.Post, url) {
+                            addHeader("Content-Type", ContentType.Application.FormUrlEncoded.toString())
+                            setBody(requestParameters.formUrlEncode())
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                        verify(exactly = 1) { mqSender.send(any()) }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/testhelper/TestApiModule.kt
@@ -1,9 +1,14 @@
 package testhelper
 
 import io.ktor.application.*
+import io.mockk.mockk
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.api.apiModule
+import no.nav.syfo.mq.MQSender
 
-fun Application.testApiModule(applicationState: ApplicationState = ApplicationState(alive = true, ready = true)) {
-    this.apiModule(applicationState = applicationState)
+fun Application.testApiModule(
+    applicationState: ApplicationState = ApplicationState(alive = true, ready = true),
+    mqSender: MQSender = mockk()
+) {
+    this.apiModule(applicationState = applicationState, mqSender = mqSender)
 }


### PR DESCRIPTION
Mock-API for å opprette dialogmelding. Parametere tilsvarende syfomock (+ `refToParent `og `refToConversation`).
Gjør foreløpig ikke annet enn å lage request-objekt fra parametere og generere en msgId som returneres i responsen. 

Swagger-dokumentasjon tilgjengelig på: https://isyfomock.dev.intern.nav.no/api/v1/docs/

Generering av XML og MQ kommer i videre PRer.