### PR TITLE
Dependabot schedule weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,15 +3,13 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
-      time: "07:00"
+      interval: weekly
     open-pull-requests-limit: 10
 
   - package-ecosystem: gradle
     directory: "/"
     schedule:
-      interval: daily
-      time: "07:00"
+      interval: weekly
     open-pull-requests-limit: 10
     groups:
       minor-and-patch:


### PR DESCRIPTION
Så vidt jeg har skjønt vil dependabot da sjekke etter versjons-oppdateringer på mandager (gjelder ikke security-updates). Tenker vi kan kjøre samme oppsett i andre backends også.
Se https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file
