### PR TITLE
Add api to send sen oppfolging varsel

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,24 +14,16 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
+      - name: Checkout code
+        uses: actions/checkout@master
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17.x'
-      - name: Checkout code
-        uses: actions/checkout@master
+          cache: 'gradle'
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v2
-      - name: Setup gradle dependency cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/.*gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Run lint
         run: |
           ./gradlew --continue ktlintCheck

--- a/api/oas3/isyfomock-api.yaml
+++ b/api/oas3/isyfomock-api.yaml
@@ -363,16 +363,16 @@ components:
     SenOppfolgingVarselRequest:
       type: object
       properties:
-        personIdent:
+        personident:
           type: string
           description: fnr til den sykmeldte
       required:
-        - personIdent
+        - personident
 
     SenOppfolgingSvarRequest:
       type: object
       properties:
-        personIdent:
+        personident:
           type: string
           description: fnr til den sykmeldte
         varselId:
@@ -407,6 +407,6 @@ components:
             }
           ]
       required:
-        - personIdent
+        - personident
         - varselId
         - response

--- a/api/oas3/isyfomock-api.yaml
+++ b/api/oas3/isyfomock-api.yaml
@@ -172,6 +172,26 @@ paths:
         '500':
           description: Internal server error
 
+  /senoppfolging/varsel:
+    post:
+      operationId: senOppfolgingVarsel
+      tags:
+        - Meroppfølging
+      summary: Sender varsel på sen oppfølging på Kafka til Modia
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SenOppfolgingVarselRequest'
+      responses:
+        '200':
+          description: Ok
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal server error
+
   /senoppfolging/svar:
     post:
       operationId: senOppfolgingSvar
@@ -339,6 +359,15 @@ components:
       required:
         - type
         - arbeidstakerFnr
+
+    SenOppfolgingVarselRequest:
+      type: object
+      properties:
+        personIdent:
+          type: string
+          description: fnr til den sykmeldte
+      required:
+        - personIdent
 
     SenOppfolgingSvarRequest:
       type: object

--- a/api/oas3/isyfomock-api.yaml
+++ b/api/oas3/isyfomock-api.yaml
@@ -376,7 +376,7 @@ components:
           type: string
           description: fnr til den sykmeldte
         varselId:
-          description: valgfri referanse til varsel det svares på
+          description: referanse til varsel det svares på
           type: string
         response:
           type: array
@@ -408,4 +408,5 @@ components:
           ]
       required:
         - personIdent
+        - varselId
         - response

--- a/api/oas3/isyfomock-api.yaml
+++ b/api/oas3/isyfomock-api.yaml
@@ -346,6 +346,9 @@ components:
         personIdent:
           type: string
           description: fnr til den sykmeldte
+        varselId:
+          description: valgfri referanse til varsel det svares på
+          type: string
         response:
           type: array
           description: svarene til den sykmeldte på sen oppfølging-skjema

--- a/src/main/kotlin/no/nav/syfo/Application.kt
+++ b/src/main/kotlin/no/nav/syfo/Application.kt
@@ -8,7 +8,9 @@ import no.nav.syfo.application.api.apiModule
 import no.nav.syfo.esyfovarsel.kafka.kafkaEsyfovarselHendelseProducerConfig
 import no.nav.syfo.esyfovarsel.model.EsyfovarselHendelse
 import no.nav.syfo.meroppfolging.kafka.kafkaSenOppfolgingSvarProducerConfig
+import no.nav.syfo.meroppfolging.kafka.kafkaSenOppfolgingVarselProducerConfig
 import no.nav.syfo.meroppfolging.model.SenOppfolgingSvar
+import no.nav.syfo.meroppfolging.model.SenOppfolgingVarsel
 import no.nav.syfo.mq.MQSender
 import no.nav.syfo.reset.kafka.kafkaTestdataResetHendelseProducerConfig
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -44,6 +46,11 @@ fun main() {
             kafkaEnvironment = environment.kafka,
         ),
     )
+    val senOppfolgingVarselProducer = KafkaProducer<String, SenOppfolgingVarsel>(
+        kafkaSenOppfolgingVarselProducerConfig(
+            kafkaEnvironment = environment.kafka,
+        ),
+    )
 
     val testdataResetProducer = KafkaProducer<String, String>(
         kafkaTestdataResetHendelseProducerConfig(
@@ -57,12 +64,13 @@ fun main() {
         }
         module {
             apiModule(
+                applicationState = applicationState,
                 mqSender = mqSender,
                 apprecMQSender = apprecMqSender,
-                applicationState = applicationState,
                 environment = environment,
                 esyfovarselHendelseProducer = esyfovarselHendelseProducer,
                 senOppfolgingSvarProducer = senOppfolgingSvarProducer,
+                senOppfolgingVarselProducer = senOppfolgingVarselProducer,
                 testdataResetKafkaProducer = testdataResetProducer,
             )
         }

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -24,8 +24,10 @@ import no.nav.syfo.esyfovarsel.EsyfovarselProducer
 import no.nav.syfo.esyfovarsel.api.registerEsyfovarselApi
 import no.nav.syfo.esyfovarsel.model.EsyfovarselHendelse
 import no.nav.syfo.meroppfolging.SenOppfolgingSvarProducer
+import no.nav.syfo.meroppfolging.SenOppfolgingVarselProducer
 import no.nav.syfo.meroppfolging.api.registerMerOppfolgingApi
 import no.nav.syfo.meroppfolging.model.SenOppfolgingSvar
+import no.nav.syfo.meroppfolging.model.SenOppfolgingVarsel
 import no.nav.syfo.motebehov.MotebehovService
 import no.nav.syfo.motebehov.api.registerMotebehovApi
 import no.nav.syfo.mq.MQSender
@@ -42,6 +44,7 @@ fun Application.apiModule(
     environment: Environment,
     esyfovarselHendelseProducer: KafkaProducer<String, EsyfovarselHendelse>,
     senOppfolgingSvarProducer: KafkaProducer<String, SenOppfolgingSvar>,
+    senOppfolgingVarselProducer: KafkaProducer<String, SenOppfolgingVarsel>,
     testdataResetKafkaProducer: KafkaProducer<String, String>,
 ) {
     install(ContentNegotiation) {
@@ -88,7 +91,6 @@ fun Application.apiModule(
     val aktorService = AktorService(pdlClient = pdlClient)
     val oppfolgingsplanService = OppfolgingsplanService(oppfolgingsplanUrl = environment.oppfolgingsplanUrl)
     val esyfovarselProducer = EsyfovarselProducer(kafkaProducer = esyfovarselHendelseProducer)
-    val senOppfolgingProducer = SenOppfolgingSvarProducer(kafkaProducer = senOppfolgingSvarProducer)
     val testdataResetProducer = TestdataResetProducer(kafkaProducer = testdataResetKafkaProducer)
 
     routing {
@@ -101,7 +103,10 @@ fun Application.apiModule(
         registerAktorApi(aktorService = aktorService)
         registerOppfolgingsplanApi(oppfolgingsplanService = oppfolgingsplanService)
         registerEsyfovarselApi(esyfovarselProducer = esyfovarselProducer)
-        registerMerOppfolgingApi(producer = senOppfolgingProducer)
+        registerMerOppfolgingApi(
+            svarProducer = SenOppfolgingSvarProducer(kafkaProducer = senOppfolgingSvarProducer),
+            varselProducer = SenOppfolgingVarselProducer(kafkaProducer = senOppfolgingVarselProducer),
+        )
         registerTestdataResetApi(producer = testdataResetProducer)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/SenOppfolgingVarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/SenOppfolgingVarselProducer.kt
@@ -1,0 +1,30 @@
+package no.nav.syfo.meroppfolging
+
+import no.nav.syfo.meroppfolging.model.SenOppfolgingVarsel
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+import java.util.*
+
+class SenOppfolgingVarselProducer(val kafkaProducer: KafkaProducer<String, SenOppfolgingVarsel>) {
+    fun sendVarsel(senOppfolgingVarsel: SenOppfolgingVarsel) {
+        try {
+            log.info("SenOppfolgingVarselProducer: Sender varsel $senOppfolgingVarsel")
+            kafkaProducer.send(
+                ProducerRecord(
+                    SEN_OPPFOLGING_VARSEL_TOPIC,
+                    UUID.randomUUID().toString(),
+                    senOppfolgingVarsel,
+                ),
+            ).get()
+        } catch (e: Exception) {
+            log.error("Exception was thrown when attempting to send varsel to $SEN_OPPFOLGING_VARSEL_TOPIC. ${e.message}")
+            throw e
+        }
+    }
+
+    companion object {
+        const val SEN_OPPFOLGING_VARSEL_TOPIC = "team-esyfo.sen-oppfolging-varsel"
+        private val log = LoggerFactory.getLogger(SenOppfolgingVarselProducer::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
@@ -16,13 +16,13 @@ import java.time.LocalDateTime
 import java.util.*
 
 object SenOppfolgingSvarRequestParameters {
-    const val personIdent = "personIdent"
+    const val personident = "personident"
     const val varselId = "varselId"
     const val response = "response"
 }
 
 object SenOppfolgingVarselRequestParameters {
-    const val personIdent = "personIdent"
+    const val personident = "personident"
 }
 
 fun Route.registerMerOppfolgingApi(
@@ -36,7 +36,7 @@ fun Route.registerMerOppfolgingApi(
         val hendelse = SenOppfolgingSvar(
             id = UUID.randomUUID(),
             varselId = UUID.fromString(formParameters.getOrFail(SenOppfolgingSvarRequestParameters.varselId)),
-            personIdent = formParameters.getOrFail(SenOppfolgingSvarRequestParameters.personIdent),
+            personIdent = formParameters.getOrFail(SenOppfolgingSvarRequestParameters.personident),
             createdAt = LocalDateTime.now(),
             response = if (response != null) mapper.readValue(response, Array<SenOppfolgingQuestionV2>::class.java).asList() else emptyList(),
         )
@@ -46,7 +46,7 @@ fun Route.registerMerOppfolgingApi(
 
     post("/senoppfolging/varsel") {
         val formParameters = call.receiveParameters()
-        val personIdent = formParameters.getOrFail(SenOppfolgingVarselRequestParameters.personIdent)
+        val personIdent = formParameters.getOrFail(SenOppfolgingVarselRequestParameters.personident)
         val varselUuid = UUID.randomUUID()
         val senOppfolgingVarsel = SenOppfolgingVarsel(
             uuid = varselUuid,

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
@@ -7,8 +7,10 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import no.nav.syfo.meroppfolging.SenOppfolgingSvarProducer
+import no.nav.syfo.meroppfolging.SenOppfolgingVarselProducer
 import no.nav.syfo.meroppfolging.model.SenOppfolgingQuestionV2
 import no.nav.syfo.meroppfolging.model.SenOppfolgingSvar
+import no.nav.syfo.meroppfolging.model.SenOppfolgingVarsel
 import no.nav.syfo.util.configuredJacksonMapper
 import java.time.LocalDateTime
 import java.util.*
@@ -19,8 +21,13 @@ object SenOppfolgingSvarRequestParameters {
     const val response = "response"
 }
 
+object SenOppfolgingVarselRequestParameters {
+    const val personIdent = "personIdent"
+}
+
 fun Route.registerMerOppfolgingApi(
-    producer: SenOppfolgingSvarProducer,
+    svarProducer: SenOppfolgingSvarProducer,
+    varselProducer: SenOppfolgingVarselProducer,
 ) {
     post("/senoppfolging/svar") {
         val mapper = configuredJacksonMapper()
@@ -34,6 +41,20 @@ fun Route.registerMerOppfolgingApi(
             response = if (response != null) mapper.readValue(response, Array<SenOppfolgingQuestionV2>::class.java).asList() else emptyList(),
         )
 
-        call.respond(HttpStatusCode.OK, producer.sendSvar(hendelse))
+        call.respond(HttpStatusCode.OK, svarProducer.sendSvar(hendelse))
+    }
+
+    post("/senoppfolging/varsel") {
+        val formParameters = call.receiveParameters()
+        val personIdent = formParameters.getOrFail(SenOppfolgingVarselRequestParameters.personIdent)
+        val varselUuid = UUID.randomUUID()
+        val senOppfolgingVarsel = SenOppfolgingVarsel(
+            uuid = varselUuid,
+            personident = personIdent,
+            createdAt = LocalDateTime.now(),
+        )
+        varselProducer.sendVarsel(senOppfolgingVarsel)
+
+        call.respond(HttpStatusCode.OK, "Varsel med uuid $varselUuid sendt til varsel-topic")
     }
 }

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
@@ -15,6 +15,7 @@ import java.util.*
 
 object SenOppfolgingSvarRequestParameters {
     const val personIdent = "personIdent"
+    const val varselId = "varselId"
     const val response = "response"
 }
 
@@ -27,6 +28,7 @@ fun Route.registerMerOppfolgingApi(
         val response = formParameters[SenOppfolgingSvarRequestParameters.response]
         val hendelse = SenOppfolgingSvar(
             id = UUID.randomUUID(),
+            varselId = formParameters[SenOppfolgingSvarRequestParameters.varselId]?.let { UUID.fromString(it) },
             personIdent = formParameters.getOrFail(SenOppfolgingSvarRequestParameters.personIdent),
             createdAt = LocalDateTime.now(),
             response = if (response != null) mapper.readValue(response, Array<SenOppfolgingQuestionV2>::class.java).asList() else emptyList(),

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/api/MerOppfolgingApi.kt
@@ -35,7 +35,7 @@ fun Route.registerMerOppfolgingApi(
         val response = formParameters[SenOppfolgingSvarRequestParameters.response]
         val hendelse = SenOppfolgingSvar(
             id = UUID.randomUUID(),
-            varselId = formParameters[SenOppfolgingSvarRequestParameters.varselId]?.let { UUID.fromString(it) },
+            varselId = UUID.fromString(formParameters.getOrFail(SenOppfolgingSvarRequestParameters.varselId)),
             personIdent = formParameters.getOrFail(SenOppfolgingSvarRequestParameters.personIdent),
             createdAt = LocalDateTime.now(),
             response = if (response != null) mapper.readValue(response, Array<SenOppfolgingQuestionV2>::class.java).asList() else emptyList(),

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/kafka/KafkaConfig.kt
@@ -13,3 +13,12 @@ fun kafkaSenOppfolgingSvarProducerConfig(
         this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = KafkaSenOppfolgingSvarSerializer::class.java.canonicalName
     }
 }
+
+fun kafkaSenOppfolgingVarselProducerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenProducerConfig(kafkaEnvironment))
+        this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = KafkaSenOppfolgingVarselSerializer::class.java.canonicalName
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/kafka/KafkaSenOppfolgingVarselSerializer.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/kafka/KafkaSenOppfolgingVarselSerializer.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.meroppfolging.kafka
+import no.nav.syfo.meroppfolging.model.SenOppfolgingVarsel
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.common.serialization.Serializer
+
+class KafkaSenOppfolgingVarselSerializer : Serializer<SenOppfolgingVarsel> {
+    private val mapper = configuredJacksonMapper()
+    override fun serialize(topic: String?, data: SenOppfolgingVarsel?): ByteArray = mapper.writeValueAsBytes(data)
+}

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/model/SenOppfolgingSvar.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/model/SenOppfolgingSvar.kt
@@ -8,6 +8,7 @@ data class SenOppfolgingSvar(
     val personIdent: String,
     val createdAt: LocalDateTime,
     val response: List<SenOppfolgingQuestionV2>,
+    val varselId: UUID?,
 )
 
 data class SenOppfolgingQuestionV2(

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/model/SenOppfolgingSvar.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/model/SenOppfolgingSvar.kt
@@ -8,7 +8,7 @@ data class SenOppfolgingSvar(
     val personIdent: String,
     val createdAt: LocalDateTime,
     val response: List<SenOppfolgingQuestionV2>,
-    val varselId: UUID?,
+    val varselId: UUID,
 )
 
 data class SenOppfolgingQuestionV2(

--- a/src/main/kotlin/no/nav/syfo/meroppfolging/model/SenOppfolgingVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/meroppfolging/model/SenOppfolgingVarsel.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.meroppfolging.model
+
+import java.time.LocalDateTime
+import java.util.*
+
+data class SenOppfolgingVarsel(
+    val uuid: UUID,
+    val personident: String,
+    val createdAt: LocalDateTime,
+)

--- a/src/test/kotlin/no/nav/syfo/meroppfolging.api/MerOppfolgingApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/meroppfolging.api/MerOppfolgingApiSpek.kt
@@ -31,7 +31,7 @@ class MerOppfolgingApiSpek : Spek(
             "ja",
         )
         val svarParams = arrayOf(
-            SenOppfolgingSvarRequestParameters.personIdent to "321",
+            SenOppfolgingSvarRequestParameters.personident to "321",
             SenOppfolgingSvarRequestParameters.varselId to varselId,
             SenOppfolgingSvarRequestParameters.response to Json.encodeAsString(
                 listOf(
@@ -40,7 +40,7 @@ class MerOppfolgingApiSpek : Spek(
             ),
         )
         val varselParams = arrayOf(
-            SenOppfolgingVarselRequestParameters.personIdent to "12345678912",
+            SenOppfolgingVarselRequestParameters.personident to "12345678912",
         )
 
         with(TestApplicationEngine()) {

--- a/src/test/kotlin/no/nav/syfo/meroppfolging.api/MerOppfolgingApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/meroppfolging.api/MerOppfolgingApiSpek.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.esyfovarsel.api
+package no.nav.syfo.meroppfolging.api
 
 import io.ktor.http.*
 import io.ktor.server.testing.*
@@ -9,10 +9,10 @@ import io.mockk.verify
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import kafka.utils.Json
-import no.nav.syfo.meroppfolging.api.SenOppfolgingSvarRequestParameters
 import no.nav.syfo.meroppfolging.model.SenOppfolgingQuestionTypeV2
 import no.nav.syfo.meroppfolging.model.SenOppfolgingQuestionV2
 import no.nav.syfo.meroppfolging.model.SenOppfolgingSvar
+import no.nav.syfo.meroppfolging.model.SenOppfolgingVarsel
 import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBeEqualTo
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -39,13 +39,17 @@ class MerOppfolgingApiSpek : Spek(
                 ),
             ),
         )
+        val varselParams = arrayOf(
+            SenOppfolgingVarselRequestParameters.personIdent to "12345678912",
+        )
 
         with(TestApplicationEngine()) {
             start()
 
-            val producer = mockk<KafkaProducer<String, SenOppfolgingSvar>>(relaxed = true)
+            val svarProducer = mockk<KafkaProducer<String, SenOppfolgingSvar>>(relaxed = true)
+            val varselProducer = mockk<KafkaProducer<String, SenOppfolgingVarsel>>(relaxed = true)
 
-            application.testApiModule(senOppfolgingSvarProducer = producer)
+            application.testApiModule(senOppfolgingSvarProducer = svarProducer, senOppfolgingVarselProducer = varselProducer)
 
             describe(MerOppfolgingApiSpek::class.java.simpleName) {
                 beforeEachTest {
@@ -70,7 +74,7 @@ class MerOppfolgingApiSpek : Spek(
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                            verify(exactly = 1) { producer.send(capture(capturedRecord)) }
+                            verify(exactly = 1) { svarProducer.send(capture(capturedRecord)) }
 
                             val capturedRecordValue = capturedRecord.captured.value()
                             assertEquals("321", capturedRecordValue.personIdent)
@@ -96,9 +100,35 @@ class MerOppfolgingApiSpek : Spek(
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
 
-                            verify(exactly = 1) { producer.send(capture(capturedRecord)) }
+                            verify(exactly = 1) { svarProducer.send(capture(capturedRecord)) }
 
                             assertEquals(varselId, capturedRecord.captured.value().varselId.toString())
+                        }
+                    }
+                }
+
+                describe("Varsel") {
+                    val url = "/senoppfolging/varsel"
+
+                    it("Sender varsel på kafka") {
+                        val capturedRecord = slot<ProducerRecord<String, SenOppfolgingVarsel>>()
+
+                        val requestParameters = listOf(
+                            *varselParams,
+                        )
+
+                        with(
+                            handleRequest(HttpMethod.Post, url) {
+                                addHeader("Content-Type", ContentType.Application.FormUrlEncoded.toString())
+                                setBody(requestParameters.formUrlEncode())
+                            },
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                            verify(exactly = 1) { varselProducer.send(capture(capturedRecord)) }
+
+                            val capturedRecordValue = capturedRecord.captured.value()
+                            assertEquals("12345678912", capturedRecordValue.personident)
                         }
                     }
                 }

--- a/src/test/kotlin/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/testhelper/TestApiModule.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.api.apiModule
 import no.nav.syfo.esyfovarsel.model.EsyfovarselHendelse
 import no.nav.syfo.meroppfolging.model.SenOppfolgingSvar
+import no.nav.syfo.meroppfolging.model.SenOppfolgingVarsel
 import no.nav.syfo.mq.MQSender
 import org.apache.kafka.clients.producer.KafkaProducer
 
@@ -15,6 +16,7 @@ fun Application.testApiModule(
     apprecMQSender: MQSender = mockk(),
     esyfovarselHendelseProducer: KafkaProducer<String, EsyfovarselHendelse> = mockk(),
     senOppfolgingSvarProducer: KafkaProducer<String, SenOppfolgingSvar> = mockk(),
+    senOppfolgingVarselProducer: KafkaProducer<String, SenOppfolgingVarsel> = mockk(),
     testdataResetProducer: KafkaProducer<String, String> = mockk(),
 ) {
     this.apiModule(
@@ -24,6 +26,7 @@ fun Application.testApiModule(
         environment = testEnvironment(),
         esyfovarselHendelseProducer = esyfovarselHendelseProducer,
         senOppfolgingSvarProducer = senOppfolgingSvarProducer,
+        senOppfolgingVarselProducer = senOppfolgingVarselProducer,
         testdataResetKafkaProducer = testdataResetProducer,
     )
 }


### PR DESCRIPTION
Slik at vi kan teste konsumering av sen oppfolging-varsel uten å måtte trigge logikk for varselutsending.